### PR TITLE
HCP burner to be executed as containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 RUN python3 -m pip install --upgrade pip || true
 RUN yes | pip3 install openshift elasticsearch==7.13.4 gitpython packaging --upgrade || true
 RUN apt-get -y update
-RUN apt-get -y install jq groff
+RUN apt-get -y install jq groff uuid-runtime
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/local/bin/rosa
 RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /usr/local/bin/ocm
 RUN curl -L https://releases.hashicorp.com/terraform/1.8.0/terraform_1.8.0_linux_amd64.zip -o terraform_1.8.0_linux_amd64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ RUN curl -L https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd6
 RUN tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 RUN python3 -m pip install --upgrade pip || true
-RUN yes | pip3 install openshift elasticsearch gitpython --upgrade || true
+RUN yes | pip3 install openshift elasticsearch==7.13.4 gitpython packaging --upgrade || true
 RUN apt-get -y update
-RUN apt-get -y install jq
+RUN apt-get -y install jq groff
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/local/bin/rosa
 RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /usr/local/bin/ocm
 RUN curl -L https://releases.hashicorp.com/terraform/1.8.0/terraform_1.8.0_linux_amd64.zip -o terraform_1.8.0_linux_amd64.zip
@@ -20,4 +20,3 @@ RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 COPY . /
-RUN yes | pip3 install openshift elasticsearch gitpython --upgrade || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+RUN curl --fail --retry 8 --retry-all-errors -sS -L "https://github.com/kube-burner/kube-burner/releases/download/v1.9.5/kube-burner-V1.9.5-linux-x86_64.tar.gz" | tar -xzC "/usr/local/bin/" kube-burner
 COPY . /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11 as runtime
+USER root
+RUN curl -L https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+RUN python3 -m pip install --upgrade pip || true
+RUN yes | pip3 install openshift --upgrade || true
+RUN apt-get -y update
+RUN apt-get -y install jq
+RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/local/bin/rosa
+RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /usr/local/bin/ocm
+RUN curl -L https://releases.hashicorp.com/terraform/1.8.0/terraform_1.8.0_linux_amd64.zip -o terraform_1.8.0_linux_amd64.zip
+RUN unzip terraform_1.8.0_linux_amd64.zip -d /usr/local/bin/
+RUN chmod +x /usr/local/bin/rosa && chmod +x /usr/local/bin/ocm && chmod +x /usr/local/bin/terraform
+RUN /usr/local/bin/rosa download openshift-client
+RUN tar xzvf openshift-client-linux.tar.gz
+RUN mv oc kubectl /usr/local/bin/
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+COPY . /

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN curl -L https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd6
 RUN tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 RUN python3 -m pip install --upgrade pip || true
-RUN yes | pip3 install openshift --upgrade || true
+RUN yes | pip3 install openshift elasticsearch gitpython --upgrade || true
 RUN apt-get -y update
 RUN apt-get -y install jq
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/local/bin/rosa
@@ -20,3 +20,4 @@ RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 COPY . /
+RUN yes | pip3 install openshift elasticsearch gitpython --upgrade || true

--- a/libs/aws.py
+++ b/libs/aws.py
@@ -37,7 +37,7 @@ class AWS:
                 self.logging.debug(f"AWS Profile: {self.aws_config[profile]}")
         else:
             self.config_file = account_file
-            self.logging.info(f"AWS Account file is not provided, so aws environment variables are being used")
+            self.logging.info("AWS Account file is not provided, so aws environment variables are being used")
 
     def set_aws_envvars(self, profile, aws_region):
         """ Get AWS information from the account_file if provided and set related environment vars"""
@@ -53,7 +53,7 @@ class AWS:
         """ Get AWS information from the account_file if provided and save it on the environment object"""
         aws = {}
         if self.config_file == "":
-            self.logging.info(f"AWS Account file is not provided, so aws environment variables are being used")
+            self.logging.info("AWS Account file is not provided, so aws environment variables are being used")
             aws['aws_access_key_id'] = os.environ["AWS_ACCESS_KEY_ID"]
             aws['aws_secret_access_key'] = os.environ["AWS_SECRET_ACCESS_KEY"]
         else:

--- a/libs/aws.py
+++ b/libs/aws.py
@@ -13,47 +13,53 @@ class AWS:
     """AWS Class"""
 
     def __init__(self, logging, account_file, profile):
+        self.logging = logging
+        self.config_file = account_file
         if os.path.exists(account_file):
-            self.logging = logging
-            self.config_file = account_file
-            logging.info("AWS account file found. Loading account information")
+            self.logging.info("AWS account file found. Loading account information")
             self.aws_config = configparser.RawConfigParser()
             self.aws_config.read(account_file)
             if len(self.aws_config.sections()) == 1:
                 profile = self.aws_config.sections()[0]
             else:
                 if not profile:
-                    logging.error("Multiple profiles detected on AWS credentials file but no --aws-profile parameter")
+                    self.logging.error("Multiple profiles detected on AWS credentials file but no --aws-profile parameter")
                     sys.exit("Exiting...")
                 else:
                     if profile not in self.aws_config.sections():
-                        logging.error(f"Profile {profile} especified as --aws-profile not found on AWS credentials file {account_file}")
+                        self.logging.error(f"Profile {profile} especified as --aws-profile not found on AWS credentials file {account_file}")
                         sys.exit("Exiting...")
             if ("aws_access_key_id" not in self.aws_config[profile] or "aws_secret_access_key" not in self.aws_config[profile]):
-                logging.error(f"Missing credentials on file {account_file} for profile {profile}")
+                self.logging.error(f"Missing credentials on file {account_file} for profile {profile}")
                 sys.exit("Exiting...")
             else:
-                logging.info(f"AWS configuration verified for profile {profile} on file {account_file}")
+                self.logging.info(f"AWS configuration verified for profile {profile} on file {account_file}")
                 self.logging.debug(f"AWS Profile: {self.aws_config[profile]}")
         else:
-            logging.error(f"AWS configuration file {account_file} especified as --aws-account-file not found")
-            sys.exit("Exiting...")
+            self.config_file = account_file
+            self.logging.info(f"AWS Account file is not provided, so aws environment variables are being used")
 
     def set_aws_envvars(self, profile, aws_region):
-        """ Get AWS information from the account_file and set related environment vars"""
-        profile = self.aws_config.sections()[0] if len(self.aws_config.sections()) == 1 else profile
-        os.environ["AWS_PROFILE"] = profile
-        os.environ["AWS_REGION"] = aws_region
-        os.environ["AWS_ACCESS_KEY_ID"] = self.aws_config[profile]["aws_access_key_id"]
-        os.environ["AWS_SECRET_ACCESS_KEY"] = self.aws_config[profile]["aws_secret_access_key"]
-        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = self.config_file
+        """ Get AWS information from the account_file if provided and set related environment vars"""
+        if self.config_file != "":
+            profile = self.aws_config.sections()[0] if len(self.aws_config.sections()) == 1 else profile
+            os.environ["AWS_PROFILE"] = profile
+            os.environ["AWS_REGION"] = aws_region
+            os.environ["AWS_ACCESS_KEY_ID"] = self.aws_config[profile]["aws_access_key_id"]
+            os.environ["AWS_SECRET_ACCESS_KEY"] = self.aws_config[profile]["aws_secret_access_key"]
+            os.environ["AWS_SHARED_CREDENTIALS_FILE"] = self.config_file
 
     def set_aws_environment(self, profile, aws_region):
-        """ Get AWS information from the account_file and save it on the environment object"""
-        profile = self.aws_config.sections()[0] if len(self.aws_config.sections()) == 1 else profile
+        """ Get AWS information from the account_file if provided and save it on the environment object"""
         aws = {}
+        if self.config_file == "":
+            self.logging.info(f"AWS Account file is not provided, so aws environment variables are being used")
+            aws['aws_access_key_id'] = os.environ["AWS_ACCESS_KEY_ID"]
+            aws['aws_secret_access_key'] = os.environ["AWS_SECRET_ACCESS_KEY"]
+        else:
+            profile = self.aws_config.sections()[0] if len(self.aws_config.sections()) == 1 else profile
+            aws['aws_access_key_id'] = self.aws_config[profile]["aws_access_key_id"]
+            aws['aws_secret_access_key'] = self.aws_config[profile]["aws_secret_access_key"]
         aws['profile'] = profile
         aws['region'] = aws_region
-        aws['aws_access_key_id'] = self.aws_config[profile]["aws_access_key_id"]
-        aws['aws_secret_access_key'] = self.aws_config[profile]["aws_secret_access_key"]
         return aws

--- a/libs/platforms/rosa/rosa.py
+++ b/libs/platforms/rosa/rosa.py
@@ -490,8 +490,8 @@ class RosaArguments(PlatformArguments):
         EnvDefault = self.EnvDefault
 
         parser.add_argument("--rosa-env", action=EnvDefault, env=environment, default='staging', envvar="HCP_BURNER_ROSA_ENV", help="ROSA Environment")
-        parser.add_argument("--aws-account-file", action=EnvDefault, env=environment, envvar="HCP_BURNER_AWS_ACCOUNT_FILE", help="File containing the AWS credentials")
-        parser.add_argument("--aws-profile", action=EnvDefault, env=environment, envvar="HCP_BURNER_AWS_PROFILE", help="Profile to use if aws file cointains more than one")
+        parser.add_argument("--aws-account-file", action=EnvDefault, env=environment, default='', envvar="HCP_BURNER_AWS_ACCOUNT_FILE", help="File containing the AWS credentials")
+        parser.add_argument("--aws-profile", action=EnvDefault, env=environment, default='localenv', envvar="HCP_BURNER_AWS_PROFILE", help="Profile to use if aws file cointains more than one")
         parser.add_argument("--aws-region", action=EnvDefault, env=environment, envvar="HCP_BURNER_AWS_REGION", default='us-east-2', help="Token to access OCM API")
         parser.add_argument("--oidc-config-id", action=EnvDefault, env=environment, envvar="HCP_BURNER_OIDC_CONFIG_ID", help="OIDC Config ID to be used on all the clusters")
         parser.add_argument("--common-operator-roles", action="store_true", help="Create one set of operator roles and use it on all clusters")
@@ -509,8 +509,6 @@ class RosaArguments(PlatformArguments):
             parser.set_defaults(**defaults)
 
         temp_args, temp_unknown_args = parser.parse_known_args()
-        if not temp_args.aws_account_file:
-            parser.error("hcp-burner.py: error: the following arguments (or equivalent definition) are required: --aws-account-file")
 
     class EnvDefault(argparse.Action):
         def __init__(self, env, envvar, default=None, **kwargs):


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

It is required for CI pipelines to be run as a container.

Changes:

1. Added a Dockerfile
2. Made aws account file as optional, it can be replaced with local env vars

Test Command:
```
podman run --env ES_SERVER=https://search-perfscale-pro-wxrjvmobqs7gsyi3xvxkqmn7am.us-west-2.es.amazonaws.com:443 --env AWS_SECRET_ACCESS_KEY=<>  --env AWS_ACCESS_KEY_ID=<>  --env AWS_REGION=us-east-2  -it 503d9fd67291 python3 hcp-burner.py
```
## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
