### PR TITLE
Refactor azure hypershift install timers

### DIFF
--- a/libs/platforms/platform.py
+++ b/libs/platforms/platform.py
@@ -52,13 +52,13 @@ class Platform:
         self.environment["workers_wait_time"] = (
             arguments["workers_wait_time"] if arguments["wait_for_workers"] else None
         )
-        if arguments["install_clusters"].lower() == "true":
+        if str(arguments["install_clusters"]).lower() == "true":
             self.environment["install_clusters"] = True
         else:
             self.environment["install_clusters"] = False
 
         self.environment['load'] = {}
-        if arguments['enable_workload'].lower() == "true":
+        if str(arguments['enable_workload']).lower() == "true":
             self.environment['load']['enabled'] = "true"
 
         self.environment['load']["workload"] = arguments["workload"]
@@ -76,7 +76,7 @@ class Platform:
 
         self.environment["wildcard_options"] = arguments["wildcard_options"]
 
-        if arguments["cleanup_clusters"].lower() == "true":
+        if str(arguments["cleanup_clusters"]).lower() == "true":
             self.environment["cleanup_clusters"] = True
             self.environment["wait_before_cleanup"] = arguments["wait_before_cleanup"]
             self.environment["delay_between_cleanup"] = arguments[


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Added controlplane ready timer
- Added total/delta timers for:
  - Install_time: time to complete the hypershift install command
  - Control Plane ready: time until OCP API is reachable
  - Cluster Ready: time until HCP is reported as ready
  - Workers Ready: time until all workers are ready

For every timer, now we **xx_total** for total time since `hypershift cluster create` is launched and **xx_delta0** for the time since the previous stage.

This is to make dashboard creation easier, following dashboard has been also modified to use new timers

Execution example: https://grafana.rdu2.scalelab.redhat.com:3000/d/tQHfAzyVz/managed-services-install-timings?orgId=1&from=now-12h&to=now&var-datasource=bDQe-DMVz&var-uuid=618d98e5-14c6-4bfa-b5f1-65732efe6d4f&var-install_method=All&var-mgmt_cluster_name=All&var-version=All&var-group_by=uuid.keyword&var-installationpercentile=90


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
