### PR TITLE
Create timestamp for indexing as the creation/deletion launch, not when finish

### DIFF
--- a/libs/platforms/azure/hypershiftcli/hypershiftcli.py
+++ b/libs/platforms/azure/hypershiftcli/hypershiftcli.py
@@ -191,6 +191,7 @@ class Hypershiftcli(Azure):
         cluster_info = platform.environment["clusters"][cluster_name]
         cluster_start_time = int(datetime.datetime.utcnow().timestamp())
         cluster_info["uuid"] = self.environment["uuid"]
+        cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
         cluster_info['mgmt_cluster_name'] = self.environment['mgmt_cluster_name']
         cluster_info["install_method"] = "hypershiftcli"
         cluster_info['resource_group_name'] = "rg-" + cluster_name
@@ -225,7 +226,6 @@ class Hypershiftcli(Azure):
             self.logging.error(err)
             self.logging.error(f"Failed to write metadata_destroy.json file located at {cluster_info['path']}")
         if self.es is not None:
-            cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
             self.es.index_metadata(cluster_info)
 
     def wait_for_cluster_ready(self, cluster_name, wait_time):
@@ -302,6 +302,7 @@ class Hypershiftcli(Azure):
         myenv["KUBECONFIG"] = self.environment['mc_kubeconfig']
         cluster_info = platform.environment["clusters"][cluster_name]
         cluster_info["uuid"] = self.environment["uuid"]
+        cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
         cluster_info["hostedclusters"] = self.environment["cluster_count"]
         cluster_info["install_method"] = "hypershiftcli"
         cluster_info['mgmt_cluster_name'] = self.environment['mgmt_cluster_name']
@@ -357,7 +358,6 @@ class Hypershiftcli(Azure):
 #        cluster_info["mc_namespace_timing"] = mc_namespace.result() - cluster_start_time if platform.environment["mc_kubeconfig"] != "" else None
 #        cluster_start_time_on_mc = mc_namespace.result()
         cluster_end_time = int(datetime.datetime.utcnow().timestamp())
-        index_time = datetime.datetime.utcnow().isoformat()
         # # Getting againg metadata to update the cluster status
         cluster_info["metadata"] = self.get_metadata(platform, cluster_name)
         cluster_info["install_duration"] = cluster_end_time - cluster_start_time
@@ -403,7 +403,6 @@ class Hypershiftcli(Azure):
             self.logging.error(err)
             self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
         if self.es is not None:
-            cluster_info["timestamp"] = index_time
             self.es.index_metadata(cluster_info)
             self.logging.info("Indexing Management cluster stats")
             os.environ["START_TIME"] = f"{cluster_start_time}"

--- a/libs/platforms/rosa/hypershift/hypershift.py
+++ b/libs/platforms/rosa/hypershift/hypershift.py
@@ -288,6 +288,7 @@ class Hypershift(Rosa):
         cluster_info = platform.environment["clusters"][cluster_name]
         cluster_start_time = int(datetime.datetime.utcnow().timestamp())
         cluster_info["uuid"] = self.environment["uuid"]
+        cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
         cluster_info["install_method"] = "rosa"
         cluster_info["mgmt_cluster_name"] = self._get_mc(cluster_info["metadata"]["cluster_id"])
         self.logging.info(f"Deleting cluster {cluster_name} on Hypershift Platform")
@@ -329,7 +330,6 @@ class Hypershift(Rosa):
             self.logging.error(err)
             self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
         if self.es is not None:
-            cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
             self.es.index_metadata(cluster_info)
 
     def _get_aws_role_name(self, cluster_name):
@@ -430,6 +430,7 @@ class Hypershift(Rosa):
         super().create_cluster(platform, cluster_name)
         cluster_info = platform.environment["clusters"][cluster_name]
         cluster_info["uuid"] = self.environment["uuid"]
+        cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
         cluster_info["hostedclusters"] = self.environment["cluster_count"]
         cluster_info["environment"] = self.environment["rosa_env"]
         cluster_info["install_method"] = "rosa"
@@ -514,7 +515,6 @@ class Hypershift(Rosa):
         else:
             cluster_info['status'] = "installed"
             cluster_end_time = int(datetime.datetime.utcnow().timestamp())
-            index_time = datetime.datetime.utcnow().isoformat()
             # Getting againg metadata to update the cluster status
             cluster_info["metadata"] = self.get_metadata(platform, cluster_name)
             cluster_info["install_duration"] = cluster_end_time - cluster_start_time
@@ -565,7 +565,6 @@ class Hypershift(Rosa):
                 self.logging.error(err)
                 self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
             if self.es is not None:
-                cluster_info["timestamp"] = index_time
                 self.es.index_metadata(cluster_info)
                 self.logging.info("Indexing Management cluster stats")
                 os.environ["START_TIME"] = f"{cluster_start_time_on_mc}"  # excludes pre-flight durations

--- a/libs/platforms/rosa/terraform/terraform.py
+++ b/libs/platforms/rosa/terraform/terraform.py
@@ -61,6 +61,7 @@ class Terraform(Rosa):
         cluster_info = platform.environment["clusters"][cluster_name]
         cluster_start_time = int(datetime.datetime.utcnow().timestamp())
         cluster_info["uuid"] = self.environment["uuid"]
+        cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
         cluster_info["install_method"] = "terraform"
         self.logging.info(f"Deleting cluster {cluster_name} on Rosa Platform using terraform")
         cleanup_code, cleanup_out, cleanup_err = self.utils.subprocess_exec("terraform apply -destroy -state=" + cluster_info['path'] + "/terraform.tfstate --auto-approve", cluster_info["path"] + "/cleanup.log", {"cwd": self.environment['path'] + "/terraform", 'preexec_fn': self.utils.disable_signals, "env": myenv})
@@ -88,7 +89,6 @@ class Terraform(Rosa):
             self.logging.error(err)
             self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
         if self.es is not None:
-            cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
             self.es.index_metadata(cluster_info)
 
     def get_workers_ready(self, kubeconfig, cluster_name):
@@ -120,6 +120,7 @@ class Terraform(Rosa):
         super().create_cluster(platform, cluster_name)
         cluster_info = platform.environment["clusters"][cluster_name]
         cluster_info["uuid"] = self.environment["uuid"]
+        cluster_info["timestamp"] = datetime.datetime.utcnow().isoformat()
         cluster_info["install_method"] = "terraform"
         self.logging.info(f"Creating cluster {cluster_info['index']} on ROSA with name {cluster_name} and {cluster_info['workers']} workers")
         cluster_info["path"] = platform.environment["path"] + "/" + cluster_name
@@ -169,7 +170,6 @@ class Terraform(Rosa):
                         return 1
                 else:
                     cluster_end_time = int(datetime.datetime.utcnow().timestamp())
-                    index_time = datetime.datetime.utcnow().isoformat()
                     break
 
         cluster_info['status'] = "installed"
@@ -203,7 +203,6 @@ class Terraform(Rosa):
             self.logging.error(err)
             self.logging.error(f"Failed to write metadata_install.json file located at {cluster_info['path']}")
         if self.es is not None:
-            cluster_info["timestamp"] = index_time
             self.es.index_metadata(cluster_info)
 
     def _wait_for_workers(self, kubeconfig, worker_nodes, wait_time, cluster_name, machinepool_name):


### PR DESCRIPTION
We are indexing data for every install at the time install finish, this is creating weird graphs on grafana.

Moving index timestamp to the start of the install/destroy process, creates better graphs, so you can easily see when the process is started just watching at the graph
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
