### PR TITLE
Fix Readme: How to convert CLI arguments to config file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Almost all the parameters can be defined in three ways:
 
 **Only parameters --platform and --subplatform must be defined as wrapper arguments, platform is always required but subplatform is optional**
 
-To add any other parameter to the config file, remove `--` from the argument and change `_` to `_`, for example:
+To add any other parameter to the config file, remove the `--` prefix from the argument and convert hyphens (-) to underscrores (_), for example:
 
 **--cluster-name-seed** will be:
 ```


### PR DESCRIPTION
- Clarified how to convert CLI arguments to config file format (hyphen to underscore)

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [X] Documentation Update

## Description

Clarified how to convert CLI arguments to config file format (hyphen to underscore), fixed the typo.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
