### PR TITLE
Use ocm list clusters for ID lookup

### DIFF
--- a/libs/platforms/platform.py
+++ b/libs/platforms/platform.py
@@ -143,11 +143,16 @@ class Platform:
 
     def get_cluster_id(self, cluster_name):
         self.logging.debug(f"Obtaining Cluster ID for cluster name {cluster_name}")
-        describe_code, describe_out, describe_err = self.utils.subprocess_exec(
-            "ocm describe cluster --json " + cluster_name,
+        list_cmd = [
+            'ocm', 'list', 'clusters',
+            f'-p=search=name=\'{cluster_name}\'',
+            '--columns', 'id', '--no-headers'
+        ]
+        list_code, list_out, list_err = self.utils.subprocess_exec(
+            list_cmd,
             extra_params={"universal_newlines": True},
         )
-        return json.loads(describe_out).get("id", None) if describe_code == 0 else None
+        return list_out.strip() if list_code == 0 else None
 
     def get_ocm_cluster_info(self, cluster_name):
         self.logging.info(f"Get Cluster metadata of {cluster_name}")

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -73,7 +73,10 @@ class Utils:
         stderr = None
         try:
             log_file = open(output_file, "w") if output_file else subprocess.PIPE
-            process = subprocess.Popen(command.split(), stdout=log_file, stderr=log_file, **extra_params)
+            if isinstance(command, list):
+                process = subprocess.Popen(command, stdout=log_file, stderr=log_file, **extra_params)
+            else:
+                process = subprocess.Popen(command.split(), stdout=log_file, stderr=log_file, **extra_params)
             stdout, stderr = process.communicate()
             if process.returncode != 0 and log_output:
                 self.logging.error(f"Failed to execute command: {command}")


### PR DESCRIPTION
Replace 'ocm describe cluster <name>' with 'ocm list clusters' filtering by name to avoid ambiguity when multiple subscriptions exist with the same cluster name.

1) Fix subscription ambiguity issue:
   The previous approach using 'ocm describe cluster <name>' would fail when
   multiple subscriptions existed with the same cluster name (from previously
   destroyed clusters), resulting in the error:

   $ ocm describe cluster '<cluster name>'
   Error: Can't retrieve cluster for key '<cluster name>':
   There are 2 subscriptions with cluster identifier or name '<cluster name>'

   The new approach uses 'ocm list clusters' which only shows active clusters,
   avoiding conflicts with historical subscription records.

2) Fix subprocess argument handling:
   After switching to the new command, subprocess was not handling the quotes
   properly in the search parameter. We moved to using list format instead of
   string commands to preserve exact quotes in our arguments and avoid
   parsing issues.

Changes:
- Switch from 'ocm describe' to 'ocm list clusters -p search=name=<name>'
- Implement list-based command arguments for reliable subprocess execution
- Update subprocess_exec to handle both string and list commands

This ensures we always get the correct active cluster even when historical subscriptions exist with duplicate names, while maintaining reliable argument passing to subprocess calls.

## Type of change

- [X] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes # 

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
