### PR TITLE
Allow the cleanup delay to be set in seconds instead of minutes

### DIFF
--- a/libs/arguments.py
+++ b/libs/arguments.py
@@ -61,7 +61,7 @@ class Arguments(argparse.ArgumentParser):
 
         self.common_parser.add_argument("--cleanup-clusters", action="store_true", help="Delete all created clusters at the end")
         self.common_parser.add_argument("--wait-before-cleanup", action=EnvDefault, env=environment, envvar="HCP_BURNER_WAIT_BEFORE_CLEANUP", help="Minutes to wait before starting the cleanup process", default=0, type=int)
-        self.common_parser.add_argument("--delay-between-cleanup", action=EnvDefault, env=environment, envvar="HCP_BURNER_DELAY_BETWEEN_CLEANUP", help="Minutes to wait between cluster deletion", default=0, type=int)
+        self.common_parser.add_argument("--delay-between-cleanup", action=EnvDefault, env=environment, envvar="HCP_BURNER_DELAY_BETWEEN_CLEANUP", help="Seconds to wait between cluster deletion", default=0, type=int)
 
         self.common_args, self.unknown_args = self.common_parser.parse_known_args()
 

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -98,7 +98,7 @@ class Utils:
         if platform.environment["wait_before_cleanup"] != 0:
             self.logging.info(f"Waiting {platform.environment['wait_before_cleanup']} minutes before starting the cluster deletion")
             time.sleep(platform.environment["wait_before_cleanup"] * 60)
-        self.logging.info(f"Attempting to start cleanup process of {len(platform.environment['clusters'])} clusters waiting {platform.environment['delay_between_cleanup']} minutes between each deletion")
+        self.logging.info(f"Attempting to start cleanup process of {len(platform.environment['clusters'])} clusters waiting {platform.environment['delay_between_cleanup']} seconds between each deletion")
         delete_cluster_thread_list = []
         for cluster_name, cluster_info in platform.environment["clusters"].items():
             self.logging.info(f"Attempting to start cleanup process of {cluster_name} on status: {cluster_info['status']}")
@@ -117,9 +117,9 @@ class Utils:
             )
             if platform.environment["delay_between_cleanup"] != 0:
                 self.logging.info(
-                    f"Waiting {platform.environment['delay_between_cleanup']} minutes before deleting the next cluster"
+                    f"Waiting {platform.environment['delay_between_cleanup']} seconds before deleting the next cluster"
                 )
-                time.sleep(platform.environment["delay_between_cleanup"] * 60)
+                time.sleep(platform.environment["delay_between_cleanup"])
         return delete_cluster_thread_list
 
     # To form the cluster_info dict for cleanup funtions


### PR DESCRIPTION
## Type of change

- [X] Optimization

## Description

Allow the delay between cleaning up clusters to be set in seconds instead of minutes. Even 1 minute takes far to long to make this test effort at large scale repeatable.
