### PR TITLE
Increase the preflight timeout to 120 minutes

### DIFF
--- a/libs/platforms/rosa/rosa.py
+++ b/libs/platforms/rosa/rosa.py
@@ -235,9 +235,9 @@ class Rosa(Platform):
         return_data = {}
         start_time = int(datetime.datetime.utcnow().timestamp())
         previous_status = ""
-        self.logging.info(f"Collecting preflight times for cluster {cluster_name} during 60 minutes until {datetime.datetime.fromtimestamp(start_time + 60 * 60)}")
+        self.logging.info(f"Collecting preflight times for cluster {cluster_name} during 120 minutes until {datetime.datetime.fromtimestamp(start_time + 120 * 60)}")
         # Waiting 1 hour for preflight checks to end
-        while datetime.datetime.utcnow().timestamp() < start_time + 60 * 60:
+        while datetime.datetime.utcnow().timestamp() < start_time + 120 * 60:
             if self.utils.force_terminate:
                 self.logging.error(f"Exiting preflight times capturing on {cluster_name} cluster after capturing Ctrl-C")
                 return 0
@@ -258,10 +258,10 @@ class Rosa(Platform):
                     self.logging.info(f"Cluster {cluster_name} is on installing status. Exiting preflights waiting...")
                     return return_data
             else:
-                self.logging.debug(f"Cluster {cluster_name} on {current_status} status. Waiting 2 seconds until {datetime.datetime.fromtimestamp(start_time + 60 * 60)} for next check")
+                self.logging.debug(f"Cluster {cluster_name} on {current_status} status. Waiting 2 seconds until {datetime.datetime.fromtimestamp(start_time + 120 * 60)} for next check")
                 time.sleep(1)
             previous_status = current_status
-        self.logging.error(f"Cluster {cluster_name} on {current_status} status (not installing) after 60 minutes. Exiting preflight waiting...")
+        self.logging.error(f"Cluster {cluster_name} on {current_status} status (not installing) after 120 minutes. Exiting preflight waiting...")
         return return_data
 
     def get_cluster_admin_access(self, cluster_name, path):


### PR DESCRIPTION
## Type of change

- [X] Refactor

## Description

Increase the preflight timeout because in faster provisioning tests (30s per HCP * 2 scripts = 4 HCPs per minute) I saw many clusters at the tail end that successfully installed however had hcp-burner related failures due to not waiting for validation to complete. This led to a number of clusters which did not record or index install metadata, worse they actually never dumped their install metadata because it could not be properly collected.