### PR TITLE
fix(elasticsearch): continue when elasticsearch is unavailable

### DIFF
--- a/hcp-burner.py
+++ b/hcp-burner.py
@@ -16,7 +16,12 @@ if __name__ == "__main__":
     ts_start = time.time()
     arguments = Arguments(os.environ)
     logging = Logging(arguments["log_level"], arguments["log_file"])
-    es = Elasticsearch(logging, arguments["es_url"], arguments["es_index"], arguments["es_insecure"], arguments["es_index_retry"]) if arguments["es_url"] else None
+    es = None
+    if arguments["es_url"]:
+        try:
+            es = Elasticsearch(logging, arguments["es_url"], arguments["es_index"], arguments["es_insecure"], arguments["es_index_retry"])
+        except SystemExit:
+            logging.warning("Elasticsearch unavailable, continuing without indexing")
     utils = Utils(logging)
 
     logging.info(f"Detected {arguments['platform']} as platform")


### PR DESCRIPTION
## Summary
- Prevent hard failures when `HCP_BURNER_ES_URL` is configured but the endpoint is unreachable/unresolvable.
- Catch Elasticsearch initialization exit in `hcp-burner.py` and continue execution without indexing.
- This keeps provisioning/test flows running while treating indexing as best-effort telemetry.

## Why this PR is separate
- This PR addresses runtime behavior only.
- CI workflow policy changes are handled in a companion PR to keep review scope clear.

## Companion PR
- CI optional + autoskip companion: https://github.com/cloud-bulldozer/hcp-burner/pull/89

## Test plan
- [x] Run `python3 -m py_compile hcp-burner.py`
- [x] Confirm branch contains only runtime code change (`hcp-burner.py`)