### PR TITLE
ci(workflows): make ES secret optional and skip unrelated PR runs

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,6 +7,14 @@ on:
   pull_request_target:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - "**/requirements*.txt"
+      - ".github/workflows/**"
+      - "Dockerfile"
+      - "bootstrap.sh"
+      - "utils/**"
+      - "*.ini"
 
 jobs:
   linters:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       HCP_BURNER_HYPERSHIFT_SERVICE_CLUSTER:
         required: true
       HCP_BURNER_ES_URL:
-        required: true
+        required: false
 jobs:
   test-rosa:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
         HCP_BURNER_OCM_TOKEN: ${{ secrets.HCP_BURNER_OCM_TOKEN }}
         HCP_BURNER_AWS_ACCOUNT_FILE: "/tmp/aws_config.ini"
         HCP_BURNER_HYPERSHIFT_SERVICE_CLUSTER: ${{ secrets.HCP_BURNER_HYPERSHIFT_SERVICE_CLUSTER}}
-        HCP_BURNER_ES_URL: ${{ secrets.HCP_BURNER_ES_URL}}
+        HCP_BURNER_ES_URL: ${{ secrets.HCP_BURNER_ES_URL || '' }}
         HCP_BURNER_ES_INDEX: "hcp-burner"
 
     # - name: Install bats


### PR DESCRIPTION
## Summary
- Make `HCP_BURNER_ES_URL` optional in the reusable tests workflow instead of required.
- Pass a safe empty default for `HCP_BURNER_ES_URL` to avoid hard workflow dependency on external ES availability.
- Add `pull_request_target.paths` filters so this CI workflow auto-skips for clearly unrelated changes.

## Why this PR is separate
- This PR changes CI policy/workflow behavior only.
- Runtime Elasticsearch fallback is handled in a separate companion PR for focused review.

## Companion PR
- Runtime graceful fallback companion: https://github.com/cloud-bulldozer/hcp-burner/pull/88

## Test plan
- [x] Parse workflow YAML locally (`tests.yml`, `pullrequest.yml`)
- [x] Confirm branch contains workflow-only changes

Made with [Cursor](https://cursor.com)